### PR TITLE
Use base image node:10.14.1-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.20.0-alpine AS builder
+FROM node:10.14.1-alpine AS builder
 
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
@@ -23,7 +23,7 @@ COPY package.json package-lock.json /app/
 
 RUN npm ci
 
-FROM node:10.20.0-alpine
+FROM node:10.14.1-alpine
 
 RUN apk --no-cache add libsasl openssl lz4-libs
 


### PR DESCRIPTION
Previously updated base image node:10.20.0-alpine caused CrashLoopBackOff when deployed to a cluster.
node:10.14.1-alpine contains ssl library of version 1.0 (while node:10.20.0-alpine - ssl 1.1 ), so it should fix this issue. Also rechecked this base image locally and in the stage, it works correctly.